### PR TITLE
Config support for stubbing Pub/Sub

### DIFF
--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -1,4 +1,5 @@
 require 'pubsub_client/version'
+require 'pubsub_client/null_publisher_factory'
 require 'pubsub_client/publisher_factory'
 
 module PubsubClient
@@ -6,43 +7,37 @@ module PubsubClient
   CredentialsError = Class.new(Error)
   ConfigurationError = Class.new(Error)
 
-  Config = Struct.new(:topic_name, :stubbed) do
-    def stubbed?
-      @stubbed || false
-    end
-  end
+  Config = Struct.new(:topic_name)
 
   class << self
     def configure(&block)
+      raise ConfigurationError, 'PubsubClient is already configured' if @publisher_factory
+
+      unless ENV['GOOGLE_APPLICATION_CREDENTIALS']
+        raise CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set.'
+      end
+
+      config = Config.new
       yield config
 
       unless config.topic_name
         raise ConfigurationError, 'The topic_name must be configured.'
       end
 
-      @publisher_factory = PublisherFactory.new(config.topic_name, config.stubbed)
+      @publisher_factory = PublisherFactory.new(config.topic_name)
     end
 
     def stub!
-      config.stubbed = true
+      raise ConfigurationError, 'PubsubClient is already configured' if @publisher_factory
+      @publisher_factory = NullPublisherFactory.new
     end
 
     def publish(message, &block)
-      unless ENV['GOOGLE_APPLICATION_CREDENTIALS']
-        raise CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set.'
-      end
-
       unless @publisher_factory
-        raise ConfigurationError, 'PubsubClient.configure must be called'
+        raise ConfigurationError, 'PubsubClient must be configured or stubbed'
       end
 
       @publisher_factory.build.publish(message, &block)
-    end
-
-    private
-
-    def config
-      @config ||= Config.new
     end
   end
 end

--- a/lib/pubsub_client/null_publisher_factory.rb
+++ b/lib/pubsub_client/null_publisher_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'null_publisher'
+
+module PubsubClient
+  # A null object to act as a publisher factory when clients are in dev or test
+  class NullPublisherFactory
+    def build
+      NullPublisher.new
+    end
+  end
+end

--- a/lib/pubsub_client/publisher_factory.rb
+++ b/lib/pubsub_client/publisher_factory.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 require_relative 'publisher'
-require_relative 'null_publisher'
 
 module PubsubClient
   # Build and memoize the Publisher, accounting for GRPC's requirements around forking.
   class PublisherFactory
-    def initialize(topic_name, stubbed)
+    def initialize(topic_name)
       @topic_name = topic_name
-      @stubbed = stubbed
       @mutex = Mutex.new
     end
 
@@ -42,7 +40,7 @@ module PubsubClient
 
     private
 
-    attr_reader :mutex, :stubbed, :topic_name
+    attr_reader :mutex, :topic_name
 
     # Used for testing to simulate when a process is forked. In those cases,
     # this helps us test that the `.build` method creates different publishers.
@@ -51,8 +49,6 @@ module PubsubClient
     end
 
     def build_publisher
-      return NullPublisher.new if stubbed
-
       pubsub = Google::Cloud::PubSub.new
       topic = pubsub.topic(topic_name)
       publisher = Publisher.new(topic)

--- a/spec/pubsub_client/publisher_factory_spec.rb
+++ b/spec/pubsub_client/publisher_factory_spec.rb
@@ -2,7 +2,7 @@
 
 module PubsubClient
   RSpec.describe PublisherFactory do
-    subject(:factory) { described_class.new('the-topic', false) }
+    subject(:factory) { described_class.new('the-topic') }
 
     let(:pubsub) { instance_double(Google::Cloud::PubSub::Project) }
     let(:topic) { instance_double(Google::Cloud::PubSub::Topic) }
@@ -62,12 +62,6 @@ module PubsubClient
 
     it 'returns the publisher' do
       expect(factory.build).to eq(publisher)
-    end
-
-    context 'when stubbed' do
-      it 'returns a NullPublisher' do
-        expect(described_class.new('the-topic', true).build).to be_a(NullPublisher)
-      end
     end
   end
 end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -3,9 +3,8 @@
 RSpec.describe PubsubClient do
   describe '.configure' do
     before do
-      described_class.stub!
       allow(PubsubClient::PublisherFactory).to receive(:new)
-        .with('the-topic', true)
+        .with('the-topic')
         .and_return('the-factory')
     end
 
@@ -13,12 +12,28 @@ RSpec.describe PubsubClient do
       described_class.instance_variable_set(:@publisher_factory, nil)
     end
 
+    context 'when no credentials are set' do
+      before do
+        described_class.instance_variable_set(:@publisher_factory, nil)
+        @gac = ENV['GOOGLE_APPLICATION_CREDENTIALS']
+        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = nil
+      end
+
+      after do
+        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @gac
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.configure { |_| }
+        end.to raise_error(PubsubClient::CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set.')
+      end
+    end
+
     context 'when the topic name is not configured' do
       it 'raises an error' do
         expect do
-          described_class.configure do |c|
-            c.topic_name = nil
-          end
+          described_class.configure { |_| }
         end.to raise_error(PubsubClient::ConfigurationError, 'The topic_name must be configured.')
       end
     end
@@ -29,6 +44,36 @@ RSpec.describe PubsubClient do
       end
       expect(described_class.instance_variable_get(:@publisher_factory))
         .to eq('the-factory')
+    end
+
+    context 'when the publisher factory has already been configured' do
+      before do
+        described_class.instance_variable_set(:@publisher_factory, 'some-factory')
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.configure { |_| }
+        end.to raise_error(PubsubClient::ConfigurationError, 'PubsubClient is already configured')
+      end
+    end
+  end
+
+  describe '.stub!' do
+    it 'returns a NullPublisherFactory' do
+      expect(described_class.stub!).to be_a(PubsubClient::NullPublisherFactory)
+    end
+
+    context 'when the publisher factory has already been configured' do
+      before do
+        described_class.instance_variable_set(:@publisher_factory, 'some-factory')
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.stub!
+        end.to raise_error(PubsubClient::ConfigurationError, 'PubsubClient is already configured')
+      end
     end
   end
 
@@ -44,27 +89,22 @@ RSpec.describe PubsubClient do
       described_class.instance_variable_set(:@publisher_factory, nil)
     end
 
-    context 'when no credentials are set' do
-      before do
-        @gac = ENV['GOOGLE_APPLICATION_CREDENTIALS']
-        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = nil
-      end
-
-      after do
-        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @gac
-      end
-
-      it 'raises an error' do
-        expect do
-          described_class.publish('foo')
-        end.to raise_error(PubsubClient::CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set.')
-      end
-    end
-
     it 'calls publish on the publisher' do
       described_class.publish('foo') { |_| }
       expect(publisher).to have_received(:publish)
         .with('foo')
+    end
+
+    context 'when the client has not been configured or stubbed' do
+      before do
+        described_class.instance_variable_set(:@publisher_factory, nil)
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.publish('foo') { |_| }
+        end.to raise_error(PubsubClient::ConfigurationError, 'PubsubClient must be configured or stubbed')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR provides configuration support for stubbing Google Cloud Pub/Sub. It introduces the classes `NullPublisher` and `NullPublisherFactory` for use in dev/test environments. These get used when calling `PubsubClient.stub!`.