### PR TITLE
Bump major version and update change log

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Version 1.0.0 2020-09-24
+------------------------
+396f5f8 Allow publishing to any topic
+
 Version 0.1.0 2020-08-25
 ------------------------
 92a2e7a Initial release

--- a/lib/pubsub_client/version.rb
+++ b/lib/pubsub_client/version.rb
@@ -1,3 +1,3 @@
 module PubsubClient
-  VERSION = '0.1.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
This bumps the major version as the recent changes to support publishing to any topic are **not** backwards compatible. 

Manually bumping since I had squashed+merged and the release script looks for merges only. 