### PR TITLE
Raise custom error if GOOGLE_APPLICATION_CREDENTIALS not set

### DIFF
--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -5,6 +5,7 @@ require 'pubsub_client/publisher_factory'
 module PubsubClient
   Error = Class.new(StandardError)
   ConfigurationError = Class.new(Error)
+  CredentialsError = Class.new(Error)
   InvalidTopicError = Class.new(Error)
 
   class << self
@@ -14,6 +15,10 @@ module PubsubClient
     end
 
     def publish(message, topic, &block)
+      unless ENV['GOOGLE_APPLICATION_CREDENTIALS']
+        raise CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set'
+      end
+
       @publisher_factory ||= PublisherFactory.new
       @publisher_factory.build(topic).publish(message, &block)
     end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -36,5 +36,22 @@ RSpec.describe PubsubClient do
       expect(publisher).to have_received(:publish)
         .with('foo')
     end
+
+    context 'when no credentials are set' do
+      before do
+        @gac = ENV['GOOGLE_APPLICATION_CREDENTIALS']
+        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = nil
+      end
+
+      after do
+        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @gac
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.publish('foo', 'the-topic')
+        end.to raise_error(PubsubClient::CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set')
+      end
+    end
   end
 end


### PR DESCRIPTION
This raises our own custom error when the `GOOGLE_APPLICATION_CREDENTIALS` are not set. Comparison of current error vs the new one from the changes in this PR:

Current
```
RuntimeError: Could not load the default credentials. Browse to
https://developers.google.com/accounts/docs/application-default-credentials
for more information
```

New error from this PR:
```
PubsubClient::CredentialsError: GOOGLE_APPLICATION_CREDENTIALS must be set
```
There are several ways in which to load credentials for an application running in GKE, but we use the combination of setting the env var above and pointing it at the mounted JSON credentials file. This is a sufficient error to reflect when these credentials are missing. 
