### PR TITLE
Add subscribe functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ end
 
 ## Usage
 
+### Publishing
+
 To publish a message to Pub/Sub, call `PubsubClient.publish(message, 'the-topic')`. This method takes any serializable object as an argument and yields a result object to a block. The `result` object has a method `#succeeded?` that returns `true` if the message was successfully published, otherwise `false`. In the latter case, there is a method `#error` that returns the error.
 
-### Example
+#### Example
 ```ruby
 PubsubClient.publish(message, 'some-topic') do |result|
   if result.succeeded?
@@ -42,6 +44,34 @@ PubsubClient.publish(message, 'some-topic') do |result|
   else
     puts result.error
   end
+end
+```
+
+### Subscribing
+
+To subscribe to a topic, a client must first get a handle to the subscriber object. After doing so, a call to `subscriber.listener` will yield two arguments: the data (most clients will only need this) and the full Pub/Sub message (for anything more robust). Optionally, a client can choose to handle exceptions raised by the subscriber.
+
+#### Example
+```ruby
+subscriber = PubsubClient.subscriber('some-topic')
+
+# Optional
+subscriber.on_error do |ex|
+  # Do something with the exception.
+end
+
+subscriber.listener(concurrency: 4, auto_ack: false) do |data, received_message|
+  # Most clients will only need the first yielded arg.
+  # It is the same as calling received_message.data
+end
+
+subscriber.subscribe # This will sleep
+```
+
+By default, the underlying subscriber will use a concurrency of `8` threads and will acknowledge all messages. If these defaults are acceptable to the client, no arguments need to be passed into the call to `listener`.
+```ruby
+subscriber.listen do |data, received_message|
+  # Do something
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,28 +49,30 @@ end
 
 ### Subscribing
 
-To subscribe to a topic, a client must first get a handle to the subscriber object. After doing so, a call to `subscriber.listener` will yield two arguments: the data (most clients will only need this) and the full Pub/Sub message (for anything more robust). Optionally, a client can choose to handle exceptions raised by the subscriber.
+To subscribe to a topic, a client must first get a handle to the subscriber object. After doing so, a call to `subscriber.listener` will yield two arguments: the data (most clients will only need this) and the full Pub/Sub message (for anything more robust). Documentation for the full message can be found [here](https://googleapis.dev/ruby/google-cloud-pubsub/latest/Google/Cloud/PubSub/ReceivedMessage.html).
+
+Optionally, a client can choose to handle exceptions raised by the subscriber. If a client chooses to do so, the listener **must** be configured before `on_error` since the latter needs a handler to the underlying listener.
 
 #### Example
 ```ruby
 subscriber = PubsubClient.subscriber('some-topic')
-
-# Optional
-subscriber.on_error do |ex|
-  # Do something with the exception.
-end
 
 subscriber.listener(concurrency: 4, auto_ack: false) do |data, received_message|
   # Most clients will only need the first yielded arg.
   # It is the same as calling received_message.data
 end
 
+# Optional
+subscriber.on_error do |ex|
+  # Do something with the exception.
+end
+
 subscriber.subscribe # This will sleep
 ```
 
-By default, the underlying subscriber will use a concurrency of `8` threads and will acknowledge all messages. If these defaults are acceptable to the client, no arguments need to be passed into the call to `listener`.
+By default, the underlying subscriber will use a concurrency of `8` threads and will acknowledge all messages. If these defaults are acceptable to the client, no arguments need to be passed in the call to `listener`.
 ```ruby
-subscriber.listen do |data, received_message|
+subscriber.listener do |data, received_message|
   # Do something
 end
 ```

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -25,11 +25,11 @@ module PubsubClient
       @publisher_factory.build(topic).publish(message, &block)
     end
 
-    def subscribe(subscription, &block)
+    def subscribe(subscription, concurrency: Subscriber::DEFAULT_CONCURRENCY, &block)
       ensure_credentials!
 
       @subscriber_factory ||= SubscriberFactory.new
-      @subscriber_factory.build(subscription).subscribe(&block)
+      @subscriber_factory.build(subscription).subscribe(concurrency, &block)
     end
 
     private

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -18,8 +18,8 @@ module PubsubClient
       @subscriber_factory = NullSubscriberFactory.new
     end
 
-    # @param message [String]
-    # @param topic [String]
+    # @param message [String] The message to publish.
+    # @param topic [String] The name of the topic to publish to.
     def publish(message, topic, &block)
       ensure_credentials!
 
@@ -27,7 +27,7 @@ module PubsubClient
       @publisher_factory.build(topic).publish(message, &block)
     end
 
-    # @param subscription [String]
+    # @param subscription [String] - The name of the topic to subscribe to.
     def subscriber(subscription)
       ensure_credentials!
 

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -25,11 +25,11 @@ module PubsubClient
       @publisher_factory.build(topic).publish(message, &block)
     end
 
-    def subscribe(subscription, concurrency: Subscriber::DEFAULT_CONCURRENCY, &block)
+    def subscribe(subscription, concurrency: Subscriber::DEFAULT_CONCURRENCY, auto_ack: true, &block)
       ensure_credentials!
 
       @subscriber_factory ||= SubscriberFactory.new
-      @subscriber_factory.build(subscription).subscribe(concurrency, &block)
+      @subscriber_factory.build(subscription).subscribe(concurrency, auto_ack, &block)
     end
 
     private

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -1,6 +1,7 @@
 require 'pubsub_client/version'
 require 'pubsub_client/null_publisher_factory'
 require 'pubsub_client/publisher_factory'
+require 'pubsub_client/subscriber_factory'
 
 module PubsubClient
   Error = Class.new(StandardError)
@@ -21,6 +22,11 @@ module PubsubClient
 
       @publisher_factory ||= PublisherFactory.new
       @publisher_factory.build(topic).publish(message, &block)
+    end
+
+    def subscribe(subscription)
+      @subscriber_factory ||= SubscriberFactory.new
+      @subscriber_factory.build(subscription).subscribe
     end
   end
 end

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -18,6 +18,8 @@ module PubsubClient
       @subscriber_factory = NullSubscriberFactory.new
     end
 
+    # @param message [String]
+    # @param topic [String]
     def publish(message, topic, &block)
       ensure_credentials!
 
@@ -25,6 +27,9 @@ module PubsubClient
       @publisher_factory.build(topic).publish(message, &block)
     end
 
+    # @param subscription [String]
+    # @param concurency [Integer]
+    # @param auto_ack [Boolean]
     def subscribe(subscription, concurrency: Subscriber::DEFAULT_CONCURRENCY, auto_ack: true, &block)
       ensure_credentials!
 

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -28,13 +28,11 @@ module PubsubClient
     end
 
     # @param subscription [String]
-    # @param concurency [Integer]
-    # @param auto_ack [Boolean]
-    def subscribe(subscription, concurrency: Subscriber::DEFAULT_CONCURRENCY, auto_ack: true, &block)
+    def subscriber(subscription)
       ensure_credentials!
 
       @subscriber_factory ||= SubscriberFactory.new
-      @subscriber_factory.build(subscription).subscribe(concurrency, auto_ack, &block)
+      @subscriber_factory.build(subscription)
     end
 
     private

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -1,5 +1,6 @@
 require 'pubsub_client/version'
 require 'pubsub_client/null_publisher_factory'
+require 'pubsub_client/null_subscriber_factory'
 require 'pubsub_client/publisher_factory'
 require 'pubsub_client/subscriber_factory'
 
@@ -13,8 +14,8 @@ module PubsubClient
   class << self
     def stub!
       raise ConfigurationError, 'PubsubClient is already configured' if @publisher_factory || @subscriber_factory
-      # Null subscriber here
       @publisher_factory = NullPublisherFactory.new
+      @subscriber_factory = NullSubscriberFactory.new
     end
 
     def publish(message, topic, &block)

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -8,6 +8,7 @@ module PubsubClient
   ConfigurationError = Class.new(Error)
   CredentialsError = Class.new(Error)
   InvalidTopicError = Class.new(Error)
+  InvalidSubscriptionError = Class.new(Error)
 
   class << self
     def stub!

--- a/lib/pubsub_client/null_subscriber.rb
+++ b/lib/pubsub_client/null_subscriber.rb
@@ -3,12 +3,8 @@
 module PubsubClient
   # A null object to act as a subscriber when clients are in dev or test
   class NullSubscriber
-    # This is required so that this publisher maintains the same contract
-    # as a real publisher.
-    NullResult = Struct.new(:data, :acknowledge!)
-
     def subscribe(*, &block)
-      yield NullResult.new
+      yield 'message'
     end
   end
 end

--- a/lib/pubsub_client/null_subscriber.rb
+++ b/lib/pubsub_client/null_subscriber.rb
@@ -3,8 +3,36 @@
 module PubsubClient
   # A null object to act as a subscriber when clients are in dev or test
   class NullSubscriber
-    def subscribe(*, &block)
-      yield 'message'
+    # This adds a subset of the available methods on the
+    # Google::Cloud::PubSub::ReceivedMessage, which is what
+    # gets yielded by the subscription when configuring the listener.
+    # For a list of methods, see the following link:
+    # https://googleapis.dev/ruby/google-cloud-pubsub/latest/Google/Cloud/PubSub/ReceivedMessage.html
+    NullResult = Struct.new(:acknowledge!) do
+      def data
+        '{"key":"value"}'
+      end
+
+      def ordering_key
+        'ordering-key'
+      end
+
+      def published_at
+        Time.now
+      end
+    end
+
+    def listener(*, &block)
+      res = NullResult.new
+      yield res.data, res
+    end
+
+    def subscribe
+      # no-op
+    end
+
+    def on_error(&block)
+      yield StandardErro.new('Boom!')
     end
   end
 end

--- a/lib/pubsub_client/null_subscriber.rb
+++ b/lib/pubsub_client/null_subscriber.rb
@@ -32,7 +32,7 @@ module PubsubClient
     end
 
     def on_error(&block)
-      yield StandardErro.new('Boom!')
+      yield StandardError.new('Boom!')
     end
   end
 end

--- a/lib/pubsub_client/null_subscriber.rb
+++ b/lib/pubsub_client/null_subscriber.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PubsubClient
+  # A null object to act as a subscriber when clients are in dev or test
+  class NullSubscriber
+    # This is required so that this publisher maintains the same contract
+    # as a real publisher.
+    NullResult = Struct.new(:data, :acknowledge!)
+
+    def subscribe(*, &block)
+      yield NullResult.new
+    end
+  end
+end

--- a/lib/pubsub_client/null_subscriber.rb
+++ b/lib/pubsub_client/null_subscriber.rb
@@ -13,10 +13,6 @@ module PubsubClient
         '{"key":"value"}'
       end
 
-      def ordering_key
-        'ordering-key'
-      end
-
       def published_at
         Time.now
       end
@@ -32,7 +28,7 @@ module PubsubClient
     end
 
     def on_error(&block)
-      yield StandardError.new('Boom!')
+      # no-op
     end
   end
 end

--- a/lib/pubsub_client/null_subscriber_factory.rb
+++ b/lib/pubsub_client/null_subscriber_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'null_subscriber'
+
+module PubsubClient
+  # A null object to act as a subscriber factory when clients are in dev or test
+  class NullSubscriberFactory
+    def build(*)
+      NullSubscriber.new
+    end
+  end
+end

--- a/lib/pubsub_client/publisher.rb
+++ b/lib/pubsub_client/publisher.rb
@@ -4,6 +4,7 @@ require 'google/cloud/pubsub'
 
 module PubsubClient
   class Publisher
+    # @param topic [Google::Cloud::PubSub::Topic]
     def initialize(topic)
       @topic = topic
     end

--- a/lib/pubsub_client/publisher_factory.rb
+++ b/lib/pubsub_client/publisher_factory.rb
@@ -10,6 +10,8 @@ module PubsubClient
       @publishers = {}
     end
 
+    # @param topic_name [String]
+    # @return [Publisher]
     def build(topic_name)
       # GRPC fails when attempting to use a connection created in a process that gets
       # forked with the message

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -12,8 +12,8 @@ module PubsubClient
     end
 
     # @param concurrency [Integer] - The number of threads to run the subscriber with.
-    # @param auto_ack [Boolean] - Flag to acknowledge the Pub/Sub message. A message must be
-    #                             acked to remove it from the topic. Default is `true`.
+    # @param auto_ack    [Boolean] - Flag to acknowledge the Pub/Sub message. A message must be
+    #                                acked to remove it from the topic. Default is `true`.
     #
     # @return [Google::Cloud::PubSub::Subscriber]
     def listener(concurrency: DEFAULT_CONCURRENCY, auto_ack: true, &block)

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'google/cloud/pubsub'
+
+module PubsubClient
+  class Subscriber
+    def initialize(topic)
+      @topic = topic
+    end
+
+
+    def subscribe
+    end
+
+    private
+
+    attr_reader :topic
+  end
+end

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -11,9 +11,9 @@ module PubsubClient
       @subscription = subscription
     end
 
-    # @param concurrency [Integer] - The number of threads to run the subscriber with.
-    # @param auto_ack    [Boolean] - Flag to acknowledge the Pub/Sub message. A message must be
-    #                                acked to remove it from the topic. Default is `true`.
+    # @param concurrency [Integer] - The number of threads to run the subscriber with. Default is 8.
+    # @param auto_ack [Boolean] - Flag to acknowledge the Pub/Sub message. A message must be acked
+    # to remove it from the topic. Default is `true`.
     #
     # @return [Google::Cloud::PubSub::Subscriber]
     def listener(concurrency: DEFAULT_CONCURRENCY, auto_ack: true, &block)

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -4,14 +4,17 @@ require 'google/cloud/pubsub'
 
 module PubsubClient
   class Subscriber
+    DEFAULT_CONCURRENCY = 8
+
     # @param subscription [Google::Cloud::PubSub::Subscription]
     def initialize(subscription)
       @subscription = subscription
     end
 
     # flag for auto-ack
-    def subscribe(&block)
-      listener = @subscription.listen do |received_message|
+    # @param concurrency [Integer]
+    def subscribe(concurrency, &block)
+      listener = @subscription.listen(threads: { callback: concurrency }) do |received_message|
         yield received_message
       end
 

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -4,16 +4,25 @@ require 'google/cloud/pubsub'
 
 module PubsubClient
   class Subscriber
-    def initialize(topic)
-      @topic = topic
+    def initialize(subscription)
+      @subscription = subscription
     end
 
+    # flag for auto-ack
+    def subscribe(&block)
+      puts 'Inside Subscriber#subscribe'
+      subscriber = @subscription.listen do |received_message|
+        yield received_message
+      end
 
-    def subscribe
+      begin
+        puts 'Starting subscriber...'
+        subscriber.start
+        sleep
+      rescue SignalException
+        subscriber.stop.wait!
+        puts 'Subscriber STOPPED'
+      end
     end
-
-    private
-
-    attr_reader :topic
   end
 end

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -16,7 +16,7 @@ module PubsubClient
     #                             acked to remove it from the topic. Default is `true`.
     #
     # @return [Google::Cloud::PubSub::Subscriber]
-    def listener(concurrency = DEFAULT_CONCURRENCY, auto_ack = true, &block)
+    def listener(concurrency: DEFAULT_CONCURRENCY, auto_ack: true, &block)
       @listener ||= begin
         @subscription.listen(threads: { callback: concurrency }) do |received_message|
           yield received_message.data, received_message

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -11,11 +11,12 @@ module PubsubClient
       @subscription = subscription
     end
 
-    # flag for auto-ack
     # @param concurrency [Integer]
-    def subscribe(concurrency, &block)
+    # @param auto_ack [Boolean]
+    def subscribe(concurrency, auto_ack, &block)
       listener = @subscription.listen(threads: { callback: concurrency }) do |received_message|
-        yield received_message
+        yield received_message.data
+        received_message.acknowledge! if auto_ack
       end
 
       begin

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -11,19 +11,37 @@ module PubsubClient
       @subscription = subscription
     end
 
-    # @param concurrency [Integer]
-    # @param auto_ack [Boolean]
-    def subscribe(concurrency, auto_ack, &block)
-      listener = @subscription.listen(threads: { callback: concurrency }) do |received_message|
-        yield received_message.data
-        received_message.acknowledge! if auto_ack
+    # @param concurrency [Integer] - The number of threads to run the subscriber with.
+    # @param auto_ack [Boolean] - Flag to acknowledge the Pub/Sub message. A message must be
+    #                             acked to remove it from the topic. Default is `true`.
+    #
+    # @return [Google::Cloud::PubSub::Subscriber]
+    def listener(concurrency = DEFAULT_CONCURRENCY, auto_ack = true, &block)
+      @listener ||= begin
+        @subscription.listen(threads: { callback: concurrency }) do |received_message|
+          yield received_message.data, received_message
+          received_message.acknowledge! if auto_ack
+        end
       end
+    end
+
+    def subscribe
+      raise ConfigurationError, 'A listener must be configured' unless @listener
 
       begin
-        listener.start
+        @listener.start
+
         sleep
       rescue SignalException
-        listener.stop.wait!
+        @listener.stop.wait!
+      end
+    end
+
+    def on_error(&block)
+      raise ConfigurationError, 'A listener must be configured' unless @listener
+
+      @listener.on_error do |exception|
+        yield exception
       end
     end
   end

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -4,24 +4,22 @@ require 'google/cloud/pubsub'
 
 module PubsubClient
   class Subscriber
+    # @param subscription [Google::Cloud::PubSub::Subscription]
     def initialize(subscription)
       @subscription = subscription
     end
 
     # flag for auto-ack
     def subscribe(&block)
-      puts 'Inside Subscriber#subscribe'
-      subscriber = @subscription.listen do |received_message|
+      listener = @subscription.listen do |received_message|
         yield received_message
       end
 
       begin
-        puts 'Starting subscriber...'
-        subscriber.start
+        listener.start
         sleep
       rescue SignalException
-        subscriber.stop.wait!
-        puts 'Subscriber STOPPED'
+        listener.stop.wait!
       end
     end
   end

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'subscriber'
+
 module PubsubClient
   class SubscriberFactory
     def initialize
@@ -18,7 +20,8 @@ module PubsubClient
 
     def build_subscriber(subscription_name)
       pubsub = Google::Cloud::PubSub.new
-      subscription = pubsub.subscription('scratch')
+      subscription = pubsub.subscription(subscription_name)
+      Subscriber.new(subscription)
     end
   end
 end

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -21,6 +21,7 @@ module PubsubClient
     def build_subscriber(subscription_name)
       pubsub = Google::Cloud::PubSub.new
       subscription = pubsub.subscription(subscription_name)
+      raise InvalidSubscriptionError, "The subscription #{subscription_name} does not exist" unless subscription
       Subscriber.new(subscription)
     end
   end

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -7,9 +7,18 @@ module PubsubClient
     end
 
     def build(subscription_name)
-      if subscribers.key?(subscription_name)
+      if @subscribers.key?(subscription_name)
         raise ConfigurationError, "PubsubClient already subscribed to #{subscription_name}"
       end
+
+      @subscribers[subscription_name] = build_subscriber(subscription_name)
+    end
+
+    private
+
+    def build_subscriber(subscription_name)
+      pubsub = Google::Cloud::PubSub.new
+      subscription = pubsub.subscription('scratch')
     end
   end
 end

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -8,6 +8,8 @@ module PubsubClient
       @subscribers = {}
     end
 
+    # @param subscription_name [String]
+    # @retrun [Subscriber]
     def build(subscription_name)
       if @subscribers.key?(subscription_name)
         raise ConfigurationError, "PubsubClient already subscribed to #{subscription_name}"

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PubsubClient
+  class SubscriberFactory
+    def initialize
+      @subscribers = {}
+    end
+
+    def build(subscription_name)
+      if subscribers.key?(subscription_name)
+        raise ConfigurationError, "PubsubClient already subscribed to #{subscription_name}"
+      end
+    end
+  end
+end

--- a/spec/pubsub_client/subscriber_factory_spec.rb
+++ b/spec/pubsub_client/subscriber_factory_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module PubsubClient
+  RSpec.describe SubscriberFactory do
+    subject(:factory) { described_class.new }
+
+    let(:pubsub) { instance_double(Google::Cloud::PubSub::Project) }
+    let(:subscription) { instance_double(Google::Cloud::PubSub::Subscription) }
+    let(:subscriber) { instance_double(Subscriber) }
+
+    before do
+      allow(Google::Cloud::PubSub)
+        .to receive(:new)
+        .and_return(pubsub)
+      allow(pubsub)
+        .to receive(:subscription)
+        .with('the-subscription')
+        .and_return(subscription)
+      allow(Subscriber)
+        .to receive(:new)
+        .and_return(subscriber)
+    end
+
+    it 'builds the subscriber' do
+      factory.build('the-subscription')
+      expect(Subscriber).to have_received(:new)
+        .with(subscription)
+    end
+
+    it 'returns the subscriber' do
+      expect(factory.build('the-subscription')).to eq(subscriber)
+    end
+
+    context 'when the subscription does not exist' do
+      before do
+        allow(pubsub)
+          .to receive(:subscription)
+          .with('invalid-subscription')
+          .and_return(nil)
+      end
+
+      it 'raises an error' do
+        expect do
+          factory.build('invalid-subscription')
+        end.to raise_error(InvalidSubscriptionError, 'The subscription invalid-subscription does not exist')
+      end
+    end
+
+    context 'when the subscription has already been subscribed to' do
+      before do
+        factory.build('the-subscription')
+      end
+
+      it 'raises an error' do
+        expect do
+          factory.build('the-subscription')
+        end.to raise_error(ConfigurationError, 'PubsubClient already subscribed to the-subscription')
+      end
+    end
+  end
+end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -27,7 +27,8 @@ module PubsubClient
         allow(subscriber).to receive(:sleep)
           .and_raise(SignalException.new('HUP'))
 
-        allow(listener).to receive(:stop) { listener }
+        allow(listener).to receive(:stop)
+          .and_return(listener)
         allow(listener).to receive(:wait!)
       end
 
@@ -35,6 +36,39 @@ module PubsubClient
         subject.subscribe(1, true)
         expect(listener).to have_received(:stop)
         expect(listener).to have_received(:wait!)
+      end
+    end
+
+    context 'listener block' do
+      let(:pubsub_message) {
+        instance_double(Google::Cloud::PubSub::ReceivedMessage, data: 'the-message', acknowledge!: nil)
+      }
+
+      before do
+        allow(subscription).to receive(:listen)
+          .with({ threads: { callback: 1 } })
+          .and_yield(pubsub_message)
+          .and_return(listener)
+      end
+
+      it 'yields the message' do
+        yielded_message = nil
+        subject.subscribe(1, true) do |message|
+          yielded_message = message
+        end
+        expect(yielded_message).to eq('the-message')
+      end
+
+      it 'acks the message' do
+        subject.subscribe(1, true) { |_| }
+        expect(pubsub_message).to have_received(:acknowledge!)
+      end
+
+      context 'when auto ack is not desired' do
+        it 'does not ack the message' do
+          subject.subscribe(1, false) { |_| }
+          expect(pubsub_message).to_not have_received(:acknowledge!)
+        end
       end
     end
   end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -21,7 +21,7 @@ module PubsubClient
     end
 
     it 'starts the subscriber' do
-      subject.subscribe(1)
+      subject.subscribe(1, true)
       expect(listener).to have_received(:start)
     end
 
@@ -35,7 +35,7 @@ module PubsubClient
       end
 
       it 'stops the subscriber' do
-        subject.subscribe(1)
+        subject.subscribe(1, true)
         expect(listener).to have_received(:stop)
         expect(listener).to have_received(:wait!)
       end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -15,12 +15,13 @@ module PubsubClient
         .to receive(:listen)
         .and_yield('the-message')
       allow(subscription).to receive(:listen)
+        .with({ threads: { callback: 1 } })
         .and_return(listener)
       allow(listener).to receive(:start)
     end
 
     it 'starts the subscriber' do
-      subject.subscribe { |_| }
+      subject.subscribe(1)
       expect(listener).to have_received(:start)
     end
 
@@ -34,7 +35,7 @@ module PubsubClient
       end
 
       it 'stops the subscriber' do
-        subject.subscribe
+        subject.subscribe(1)
         expect(listener).to have_received(:stop)
         expect(listener).to have_received(:wait!)
       end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -5,7 +5,7 @@ module PubsubClient
     subject(:subscriber) { described_class.new(subscription) }
 
     let(:subscription) { instance_double(Google::Cloud::PubSub::Subscription) }
-    let(:google_subscriber) { instance_double(Google::Cloud::PubSub::Subscriber) }
+    let(:listener) { instance_double(Google::Cloud::PubSub::Subscriber) }
 
     before do
       # This must be stubbed out so that the process that runs the specs doesn't
@@ -15,13 +15,13 @@ module PubsubClient
         .to receive(:listen)
         .and_yield('the-message')
       allow(subscription).to receive(:listen)
-        .and_return(google_subscriber)
-      allow(google_subscriber).to receive(:start)
+        .and_return(listener)
+      allow(listener).to receive(:start)
     end
 
     it 'starts the subscriber' do
       subject.subscribe { |_| }
-      expect(google_subscriber).to have_received(:start)
+      expect(listener).to have_received(:start)
     end
 
     context 'when there is a SignalException' do
@@ -29,14 +29,14 @@ module PubsubClient
         allow(subscriber).to receive(:sleep)
           .and_raise(SignalException.new('HUP'))
 
-        allow(google_subscriber).to receive(:stop) { google_subscriber }
-        allow(google_subscriber).to receive(:wait!)
+        allow(listener).to receive(:stop) { listener }
+        allow(listener).to receive(:wait!)
       end
 
       it 'stops the subscriber' do
         subject.subscribe
-        expect(google_subscriber).to have_received(:stop)
-        expect(google_subscriber).to have_received(:wait!)
+        expect(listener).to have_received(:stop)
+        expect(listener).to have_received(:wait!)
       end
     end
 
@@ -45,7 +45,7 @@ module PubsubClient
       subject.subscribe do |result|
         yielded_result = result
       end
-      google_subscriber.start
+      listener.start
       expect(yielded_result).to eq('the-result')
     end
   end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module PubsubClient
+  RSpec.describe Subscriber do
+    subject(:subscriber) { described_class.new(subscription) }
+
+    let(:subscription) { instance_double(Google::Cloud::PubSub::Subscription) }
+    let(:google_subscriber) { instance_double(Google::Cloud::PubSub::Subscriber) }
+
+    before do
+      # This must be stubbed out so that the process that runs the specs doesn't
+      # actually sleep.
+      allow(subscriber).to receive(:sleep)
+      allow(subscription)
+        .to receive(:listen)
+        .and_yield('the-message')
+      allow(subscription).to receive(:listen)
+        .and_return(google_subscriber)
+      allow(google_subscriber).to receive(:start)
+    end
+
+    it 'starts the subscriber' do
+      subject.subscribe { |_| }
+      expect(google_subscriber).to have_received(:start)
+    end
+
+    context 'when there is a SignalException' do
+      before do
+        allow(subscriber).to receive(:sleep)
+          .and_raise(SignalException.new('HUP'))
+
+        allow(google_subscriber).to receive(:stop) { google_subscriber }
+        allow(google_subscriber).to receive(:wait!)
+      end
+
+      it 'stops the subscriber' do
+        subject.subscribe
+        expect(google_subscriber).to have_received(:stop)
+        expect(google_subscriber).to have_received(:wait!)
+      end
+    end
+
+    xit 'yields the result to a block' do
+      yielded_result = nil
+      subject.subscribe do |result|
+        yielded_result = result
+      end
+      google_subscriber.start
+      expect(yielded_result).to eq('the-result')
+    end
+  end
+end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -11,9 +11,6 @@ module PubsubClient
       # This must be stubbed out so that the process that runs the specs doesn't
       # actually sleep.
       allow(subscriber).to receive(:sleep)
-      allow(subscription)
-        .to receive(:listen)
-        .and_yield('the-message')
       allow(subscription).to receive(:listen)
         .with({ threads: { callback: 1 } })
         .and_return(listener)
@@ -39,15 +36,6 @@ module PubsubClient
         expect(listener).to have_received(:stop)
         expect(listener).to have_received(:wait!)
       end
-    end
-
-    xit 'yields the result to a block' do
-      yielded_result = nil
-      subject.subscribe do |result|
-        yielded_result = result
-      end
-      listener.start
-      expect(yielded_result).to eq('the-result')
     end
   end
 end

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -15,7 +15,7 @@ module PubsubClient
       # actually sleep.
       allow(subscriber).to receive(:sleep)
       allow(subscription).to receive(:listen)
-        .with({ threads: { callback: 1 } })
+        .with({ threads: { callback: 8 } })
         .and_yield(pubsub_message)
         .and_return(listener)
       allow(listener).to receive(:start)
@@ -23,20 +23,20 @@ module PubsubClient
 
     describe '.subscribe' do
       it 'starts the listener' do
-        subject.listener(1, true) { |_,_| }
+        subject.listener { |_,_| }
         subject.subscribe
         expect(listener).to have_received(:start)
       end
 
       it 'acks the message' do
-        subject.listener(1, true) { |_,_| }
+        subject.listener { |_,_| }
         subject.subscribe
         expect(pubsub_message).to have_received(:acknowledge!)
       end
 
       context 'when auto ack is not desired' do
         it 'does not ack the message' do
-          subject.listener(1, false) { |_,_| }
+          subject.listener(auto_ack: false) { |_,_| }
           subject.subscribe
           expect(pubsub_message).to_not have_received(:acknowledge!)
         end
@@ -61,7 +61,7 @@ module PubsubClient
         end
 
         it 'stops the subscriber' do
-          subject.listener(1, true) { |_,_| }
+          subject.listener { |_,_| }
           subject.subscribe
           expect(listener).to have_received(:stop)
           expect(listener).to have_received(:wait!)

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -6,6 +6,9 @@ module PubsubClient
 
     let(:subscription) { instance_double(Google::Cloud::PubSub::Subscription) }
     let(:listener) { instance_double(Google::Cloud::PubSub::Subscriber) }
+    let(:pubsub_message) {
+      instance_double(Google::Cloud::PubSub::ReceivedMessage, data: 'the-message', acknowledge!: nil)
+    }
 
     before do
       # This must be stubbed out so that the process that runs the specs doesn't
@@ -13,61 +16,83 @@ module PubsubClient
       allow(subscriber).to receive(:sleep)
       allow(subscription).to receive(:listen)
         .with({ threads: { callback: 1 } })
+        .and_yield(pubsub_message)
         .and_return(listener)
       allow(listener).to receive(:start)
     end
 
-    it 'starts the subscriber' do
-      subject.subscribe(1, true)
-      expect(listener).to have_received(:start)
-    end
-
-    context 'when there is a SignalException' do
-      before do
-        allow(subscriber).to receive(:sleep)
-          .and_raise(SignalException.new('HUP'))
-
-        allow(listener).to receive(:stop)
-          .and_return(listener)
-        allow(listener).to receive(:wait!)
-      end
-
-      it 'stops the subscriber' do
-        subject.subscribe(1, true)
-        expect(listener).to have_received(:stop)
-        expect(listener).to have_received(:wait!)
-      end
-    end
-
-    context 'listener block' do
-      let(:pubsub_message) {
-        instance_double(Google::Cloud::PubSub::ReceivedMessage, data: 'the-message', acknowledge!: nil)
-      }
-
-      before do
-        allow(subscription).to receive(:listen)
-          .with({ threads: { callback: 1 } })
-          .and_yield(pubsub_message)
-          .and_return(listener)
-      end
-
-      it 'yields the message' do
-        yielded_message = nil
-        subject.subscribe(1, true) do |message|
-          yielded_message = message
-        end
-        expect(yielded_message).to eq('the-message')
+    describe '.subscribe' do
+      it 'starts the listener' do
+        subject.listener(1, true) { |_,_| }
+        subject.subscribe
+        expect(listener).to have_received(:start)
       end
 
       it 'acks the message' do
-        subject.subscribe(1, true) { |_| }
+        subject.listener(1, true) { |_,_| }
+        subject.subscribe
         expect(pubsub_message).to have_received(:acknowledge!)
       end
 
       context 'when auto ack is not desired' do
         it 'does not ack the message' do
-          subject.subscribe(1, false) { |_| }
+          subject.listener(1, false) { |_,_| }
+          subject.subscribe
           expect(pubsub_message).to_not have_received(:acknowledge!)
+        end
+      end
+
+      context 'when there is no listener configured' do
+        it 'raises a configuration error' do
+          expect do
+            subject.subscribe { |_| }
+          end.to raise_error(PubsubClient::ConfigurationError, 'A listener must be configured')
+        end
+      end
+
+      context 'when there is a SignalException' do
+        before do
+          allow(subject).to receive(:sleep)
+            .and_raise(SignalException.new('HUP'))
+
+          allow(listener).to receive(:stop)
+            .and_return(listener)
+          allow(listener).to receive(:wait!)
+        end
+
+        it 'stops the subscriber' do
+          subject.listener(1, true) { |_,_| }
+          subject.subscribe
+          expect(listener).to have_received(:stop)
+          expect(listener).to have_received(:wait!)
+        end
+      end
+    end
+
+    describe '.on_error' do
+      before do
+        subject.instance_variable_set(:@listener, listener)
+        allow(listener).to receive(:on_error)
+          .and_yield(StandardError.new('Boom!'))
+      end
+
+      it 'yields the exception' do
+        yielded_ex = nil
+        subject.on_error do |ex|
+          yielded_ex = ex
+        end
+        expect(yielded_ex.message).to eq('Boom!')
+      end
+
+      context 'when there is no listener configured' do
+        before do
+          subject.instance_variable_set(:@listener, nil)
+        end
+
+        it 'raises a configuration error' do
+          expect do
+            subject.on_error { |_| }
+          end.to raise_error(PubsubClient::ConfigurationError, 'A listener must be configured')
         end
       end
     end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -2,13 +2,35 @@
 
 RSpec.describe PubsubClient do
   describe '.stub!' do
-    it 'returns a NullPublisherFactory' do
-      expect(described_class.stub!).to be_a(PubsubClient::NullPublisherFactory)
+    context 'it sets the null factories' do
+      before(:all) do
+        described_class.stub!
+      end
+
+      it 'sets a NullPublisherFactory as the publisher factory' do
+        expect(described_class.instance_variable_get(:@publisher_factory)).to be_a(PubsubClient::NullPublisherFactory)
+      end
+
+      it 'sets a NullSubscriberFactory as the subscriber factory' do
+        expect(described_class.instance_variable_get(:@subscriber_factory)).to be_a(PubsubClient::NullSubscriberFactory)
+      end
     end
 
     context 'when the publisher factory has already been configured' do
       before do
         described_class.instance_variable_set(:@publisher_factory, 'some-factory')
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.stub!
+        end.to raise_error(PubsubClient::ConfigurationError, 'PubsubClient is already configured')
+      end
+    end
+
+    context 'when the subscriber factory has already been configured' do
+      before do
+        described_class.instance_variable_set(:@subscriber_factory, 'some-factory')
       end
 
       it 'raises an error' do
@@ -70,6 +92,23 @@ RSpec.describe PubsubClient do
     it 'calls subscribe on the subscriber' do
       described_class.subscribe('foo')
       expect(subscriber).to have_received(:subscribe)
+    end
+
+    context 'when no credentials are set' do
+      before do
+        @gac = ENV['GOOGLE_APPLICATION_CREDENTIALS']
+        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = nil
+      end
+
+      after do
+        ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @gac
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.subscribe('foo')
+        end.to raise_error(PubsubClient::CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set')
+      end
     end
   end
 end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PubsubClient do
     end
 
     it 'calls publish on the publisher' do
-      described_class.publish('foo', 'the-topic') { |_| }
+      described_class.publish('foo', 'the-topic')
       expect(publisher).to have_received(:publish)
         .with('foo')
     end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe PubsubClient do
     it 'calls subscribe on the subscriber' do
       described_class.subscribe('foo')
       expect(subscriber).to have_received(:subscribe)
-        .with('foo')
     end
   end
 end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe PubsubClient do
     end
   end
 
-  describe '.subscribe' do
-    let(:subscriber) { instance_double(PubsubClient::Subscriber, subscribe: nil) }
+  describe '.subscriber' do
+    let(:subscriber) { instance_double(PubsubClient::Subscriber, listener: nil) }
 
     before do
       factory = instance_double(PubsubClient::SubscriberFactory, build: subscriber)
@@ -89,9 +89,9 @@ RSpec.describe PubsubClient do
       described_class.instance_variable_set(:@subscriber_factory, nil)
     end
 
-    it 'calls subscribe on the subscriber' do
-      described_class.subscribe('foo')
-      expect(subscriber).to have_received(:subscribe)
+    it 'it returns the subscriber' do
+      described_class.subscriber('foo')
+      expect(described_class.subscriber('foo')).to eq(subscriber)
     end
 
     context 'when no credentials are set' do
@@ -106,7 +106,7 @@ RSpec.describe PubsubClient do
 
       it 'raises an error' do
         expect do
-          described_class.subscribe('foo')
+          described_class.subscriber('foo')
         end.to raise_error(PubsubClient::CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set')
       end
     end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -54,4 +54,23 @@ RSpec.describe PubsubClient do
       end
     end
   end
+
+  describe '.subscribe' do
+    let(:subscriber) { instance_double(PubsubClient::Subscriber, subscribe: nil) }
+
+    before do
+      factory = instance_double(PubsubClient::SubscriberFactory, build: subscriber)
+      described_class.instance_variable_set(:@subscriber_factory, factory)
+    end
+
+    after do
+      described_class.instance_variable_set(:@subscriber_factory, nil)
+    end
+
+    it 'calls subscribe on the subscriber' do
+      described_class.subscribe('foo')
+      expect(subscriber).to have_received(:subscribe)
+        .with('foo')
+    end
+  end
 end


### PR DESCRIPTION
This adds the ability to subscribe to a Pub/Sub topic. Of note, we expose two additional configuration params:
- `concurrency`: the number of threads the subscriber will run to process messages (defaults to 8 threads)
-  `auto_ack`: flag to auto ack messages (default is `true` and _will_ ack messages)

These changes come with a handful of useful checks:
- ensures credentials are configured prior to subscribing
- raises an error if the target subscription does not exist
- raises an error if attempting to subscribe to a topic that has already been subscribed to

Usage is outlined in the updated README.