### PR TITLE
Pass published attributes all the way through the client

### DIFF
--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -20,11 +20,11 @@ module PubsubClient
 
     # @param message [String] The message to publish.
     # @param topic [String] The name of the topic to publish to.
-    def publish(message, topic, &block)
+    def publish(message, topic, attributes = {}, &block)
       ensure_credentials!
 
       @publisher_factory ||= PublisherFactory.new
-      @publisher_factory.build(topic).publish(message, &block)
+      @publisher_factory.build(topic).publish(message, attributes, &block)
     end
 
     # @param subscription [String] - The name of the topic to subscribe to.

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe PubsubClient do
     it 'calls publish on the publisher' do
       described_class.publish('foo', 'the-topic')
       expect(publisher).to have_received(:publish)
-        .with('foo')
+        .with('foo', {})
     end
 
     context 'when no credentials are set' do


### PR DESCRIPTION
In #16 I missed modifying the API of the `publish` method that the client exposes to accept attributes when publishing messages.