### PR TITLE
Do not require GAC when stubbed

### DIFF
--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -16,6 +16,7 @@ module PubsubClient
       raise ConfigurationError, 'PubsubClient is already configured' if @publisher_factory || @subscriber_factory
       @publisher_factory = NullPublisherFactory.new
       @subscriber_factory = NullSubscriberFactory.new
+      @stubbed = true
     end
 
     # @param message [String] The message to publish.
@@ -38,6 +39,7 @@ module PubsubClient
     private
 
     def ensure_credentials!
+      return if defined?(@stubbed) && @stubbed
       unless ENV['GOOGLE_APPLICATION_CREDENTIALS']
         raise CredentialsError, 'GOOGLE_APPLICATION_CREDENTIALS must be set'
       end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -2,11 +2,15 @@
 
 RSpec.describe PubsubClient do
   describe '.stub!' do
-    context 'it sets the null factories' do
-      before(:all) do
-        described_class.stub!
-      end
+    before(:all) do
+      described_class.stub!
+    end
 
+    after(:all) do
+      described_class.instance_variable_set(:@stubbed, nil)
+    end
+
+    context 'it sets the null factories' do
       it 'sets a NullPublisherFactory as the publisher factory' do
         expect(described_class.instance_variable_get(:@publisher_factory)).to be_a(PubsubClient::NullPublisherFactory)
       end
@@ -38,6 +42,18 @@ RSpec.describe PubsubClient do
           described_class.stub!
         end.to raise_error(PubsubClient::ConfigurationError, 'PubsubClient is already configured')
       end
+    end
+
+    it 'does not require credentials for publishing' do
+      expect do
+        described_class.publish('foo', 'the-topic') { }
+      end.to_not raise_error
+    end
+
+    it 'does not require credentials for getting a handle to a subscriber' do
+      expect do
+        described_class.subscriber('foo')
+      end.to_not raise_error
     end
   end
 


### PR DESCRIPTION
The previous logic was still making a check for the env var
`GOOGLE_APPLICATION_CREDENTIALS` even if the client was stubbed.
This remedies that by checking the existence and value of the
instance variable `@stubbed`, which is only set when the client
is stubbed.

I unintentionally removed this when I added the subscribing functionality in #14 . 

Currently:
```ruby
[1] pry(main)> PubsubClient.stub!
=> #<PubsubClient::NullSubscriberFactory:0x00007f94e4588bf0>
[2] pry(main)> PubsubClient.publish("message", "topic") { }
PubsubClient::CredentialsError: GOOGLE_APPLICATION_CREDENTIALS must be set
from /Users/simonsanchez/dev/pubsub_client/lib/pubsub_client.rb:42:in `ensure_credentials!'
```

With this change:
```ruby
[1] pry(main)> PubsubClient.stub!
=> true
[2] pry(main)> PubsubClient.publish("message", "topic") { }
=> nil
```