### PR TITLE
Update subscriber example to include name of subscription instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Optionally, a client can choose to handle exceptions raised by the subscriber. I
 
 #### Example
 ```ruby
-subscriber = PubsubClient.subscriber('some-topic')
+subscriber = PubsubClient.subscriber('some-subscription')
 
 subscriber.listener(concurrency: 4, auto_ack: false) do |data, received_message|
   # Most clients will only need the first yielded arg.

--- a/lib/pubsub_client.rb
+++ b/lib/pubsub_client.rb
@@ -28,7 +28,7 @@ module PubsubClient
       @publisher_factory.build(topic).publish(message, attributes, &block)
     end
 
-    # @param subscription [String] - The name of the topic to subscribe to.
+    # @param subscription [String] - The name of the subscription to subscribe to.
     def subscriber(subscription)
       ensure_credentials!
 


### PR DESCRIPTION
…topic

Updating subscriber example and comment to specify the param is a subscription name, and not a topic name.