### PR TITLE
[PLAT-1657] Support for synchronous publishers

### DIFF
--- a/lib/pubsub_client/null_publisher.rb
+++ b/lib/pubsub_client/null_publisher.rb
@@ -14,5 +14,9 @@ class PubsubClient
     def publish(*, &block)
       yield NullResult.new
     end
+
+    def synchronous_publish(*, &block)
+      # no-op
+    end
   end
 end

--- a/lib/pubsub_client/publisher.rb
+++ b/lib/pubsub_client/publisher.rb
@@ -13,6 +13,15 @@ class PubsubClient
       topic.publish_async(message, attributes, &block)
     end
 
+    # https://googleapis.dev/ruby/google-cloud-pubsub/latest/Google/Cloud/PubSub/Topic.html#publish-instance_method
+    #
+    # @return [Google::Cloud::PubSub::Message | Array<Google::Cloud::PubSub::Message>]
+    #         Returns the published message when called without a block, or an array of messages
+    #         when called with a block.
+    def synchronous_publish(message, attributes = {}, &block)
+      topic.publish(message, attributes, &block)
+    end
+
     def flush
       return unless topic.async_publisher
       topic.async_publisher.stop.wait!

--- a/lib/pubsub_client/version.rb
+++ b/lib/pubsub_client/version.rb
@@ -1,3 +1,3 @@
 class PubsubClient
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/pubsub_client/null_publisher_spec.rb
+++ b/spec/pubsub_client/null_publisher_spec.rb
@@ -5,22 +5,26 @@ class PubsubClient
     subject { described_class.new }
 
     describe '.publish' do
-      context 'when calling methods from the real contract' do
-        it 'responds to succeeded?' do
-          yielded_result = nil
-          subject.publish('foo') do |result|
-            yielded_result = result
-          end
-          expect(yielded_result.succeeded?).to eq(true)
+      it 'responds to succeeded?' do
+        yielded_result = nil
+        subject.publish('foo') do |result|
+          yielded_result = result
         end
+        expect(yielded_result.succeeded?).to eq(true)
+      end
 
-        it 'responds to error' do
-          yielded_result = nil
-          subject.publish('foo') do |result|
-            yielded_result = result
-          end
-          expect(yielded_result.error).to be_nil
+      it 'responds to error' do
+        yielded_result = nil
+        subject.publish('foo') do |result|
+          yielded_result = result
         end
+        expect(yielded_result.error).to be_nil
+      end
+    end
+
+    describe '.synchronous_publish' do
+      it 'returns nil' do
+        expect(subject.synchronous_publish('foo')).to be_nil
       end
     end
   end

--- a/spec/pubsub_client/publisher_factory_spec.rb
+++ b/spec/pubsub_client/publisher_factory_spec.rb
@@ -118,5 +118,19 @@ class PubsubClient
           .once
       end
     end
+
+    context 'synchronous publisher' do
+      before do
+        allow(Google::Cloud::PubSub)
+          .to receive(:new)
+          .and_return(pubsub)
+      end
+
+      it 'builds the synchronous publisher' do
+        factory.build('the-topic', 5)
+        expect(Google::Cloud::Pubsub).to have_received(:new)
+          .with(timeout: 5)
+      end
+    end
   end
 end

--- a/spec/pubsub_client/publisher_spec.rb
+++ b/spec/pubsub_client/publisher_spec.rb
@@ -6,30 +6,50 @@ class PubsubClient
 
     let(:topic) { instance_double(Google::Cloud::PubSub::Topic) }
 
-    before do
-      allow(topic)
-        .to receive(:publish_async)
-        .and_yield('the-result')
-    end
-
-    it 'publishes the message asynchronously' do
-      subject.publish('foo') { |_| }
-      expect(topic).to have_received(:publish_async)
-        .with('foo', {})
-    end
-
-    it 'supports attributes' do
-      subject.publish('foo', bar: 'baz') { |_| }
-      expect(topic).to have_received(:publish_async)
-        .with('foo', {bar: 'baz'})
-    end
-
-    it 'yields the result to a block' do
-      yielded_result = nil
-      subject.publish('foo') do |result|
-        yielded_result = result
+    describe 'async publishing' do
+      before do
+        allow(topic)
+          .to receive(:publish_async)
+          .and_yield('the-result')
       end
-      expect(yielded_result).to eq('the-result')
-    end
-  end
+
+      it 'publishes the message' do
+        subject.publish('foo') { |_| }
+        expect(topic).to have_received(:publish_async)
+          .with('foo', {})
+      end
+
+      it 'supports attributes' do
+        subject.publish('foo', bar: 'baz') { |_| }
+        expect(topic).to have_received(:publish_async)
+          .with('foo', {bar: 'baz'})
+      end
+
+      it 'yields the result to a block' do
+        yielded_result = nil
+        subject.publish('foo') do |result|
+          yielded_result = result
+        end
+        expect(yielded_result).to eq('the-result')
+      end
+    end # describe
+
+    describe 'synchronous publishing' do
+      before do
+        allow(topic).to receive(:publish)
+      end
+
+      it 'publishes the message' do
+        subject.synchronous_publish('foo')
+        expect(topic).to have_received(:publish)
+          .with('foo', {})
+      end
+
+      it 'supports attributes' do
+        subject.synchronous_publish('foo', bar: 'baz')
+        expect(topic).to have_received(:publish)
+          .with('foo', {bar: 'baz'})
+      end
+    end # describe
+  end # Rspec
 end

--- a/spec/pubsub_client_spec.rb
+++ b/spec/pubsub_client_spec.rb
@@ -15,6 +15,33 @@ RSpec.describe PubsubClient do
       @client.instance_variable_set(:@stubbed, nil)
     end
 
+    context 'config' do
+      it 'default sets publish_timeout to nil' do
+        expect(@client.config.publish_timeout).to be_nil
+      end
+
+      context 'when config is set' do
+        let(:publish_timeout) { 5 }
+
+        before do
+          @original_publish_timeout = @client.config.publish_timeout
+          @client.configure do |c|
+            c.publish_timeout = publish_timeout
+          end
+        end
+
+        after do
+          @client.configure do |c|
+            c.publish_timeout = @original_publish_timeout
+          end
+        end
+
+        it 'sets the configured value' do
+          expect(@client.config.publish_timeout).to eq(publish_timeout)
+        end
+      end
+    end
+
     context 'it sets the null factories' do
       it 'sets a NullPublisherFactory as the publisher factory' do
         expect(@client.instance_variable_get(:@publisher_factory)).to be_a(PubsubClient::NullPublisherFactory)


### PR DESCRIPTION
Helping out the Drive team. 

So far things look good. I was able to successfully publish both synchronous and async (to make sure I didn't break anything). See the screenshot below. 

Code I used for publishing:
```ruby
## Publish

topic = "dataprivacy-api"
attrs = { event: "user_data_redacted" }
publish_timeout = 1

client = PubsubClient.new
client.configure do |c|
  c.publish_timeout = publish_timeout
end

10.times do |i|
  payload = { "key#{i}" => "unix=#{Time.now.to_i}", "publish_timeout" => publish_timeout }.to_json
  result = client.synchronous_publish(payload, topic, attrs)
  puts result.message_id
  sleep 1
end

10.times do |i|
  payload = { "key#{i}" => "unix=#{Time.now.to_i}", "async" => true }.to_json
  client.publish(payload, topic, attrs) do |result|
    if result.succeeded?
      puts "async publish success #{i}"
    else
      puts result.error
    end
  end
end

puts "** done publishing **"
```
<img width="1065" alt="Screen Shot 2022-04-20 at 18 15 12" src="https://user-images.githubusercontent.com/11762747/164352748-02a766f4-1ce4-43a2-b9c0-b58052ca73d4.png">
 