### PR TITLE
[SRE-2134] Update google-cloud-pubsub to latest

### DIFF
--- a/lib/pubsub_client/version.rb
+++ b/lib/pubsub_client/version.rb
@@ -1,3 +1,3 @@
 class PubsubClient
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end

--- a/pubsub_client.gemspec
+++ b/pubsub_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'google-cloud-pubsub', '~> 2.0'
+  spec.add_runtime_dependency 'google-cloud-pubsub', '~> 2.15.4'
   spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
CI pipeline recently failed for `paperinvoices` due to vulnerabilities related to the `grpc` gem which is a dependency for `google-cloud-pubsub`. Note that any service using the `pubsub_client` gem will be impacted. For that reason, an updated version will need to be released with the latest `google-cloud-pubsub` gem.

```
[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.194Z] CVE: CVE-2023-1428

[2023-08-29T20:04:36.194Z] GHSA: GHSA-6628-q6j9-w8vg

[2023-08-29T20:04:36.194Z] Criticality: High

[2023-08-29T20:04:36.194Z] URL: https://github.com/grpc/grpc/issues/33463

[2023-08-29T20:04:36.194Z] Title: gRPC Reachable Assertion issue

[2023-08-29T20:04:36.194Z] Solution: upgrade to >= 1.53.0

[2023-08-29T20:04:36.194Z] 

[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.194Z] CVE: CVE-2023-32731

[2023-08-29T20:04:36.194Z] GHSA: GHSA-cfgp-2977-2fmm

[2023-08-29T20:04:36.194Z] Criticality: High

[2023-08-29T20:04:36.194Z] URL: https://github.com/grpc/grpc/issues/33463

[2023-08-29T20:04:36.194Z] Title: Connection confusion in gRPC

[2023-08-29T20:04:36.194Z] Solution: upgrade to >= 1.53.1

[2023-08-29T20:04:36.194Z] 

[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.194Z] CVE: CVE-2023-32732

[2023-08-29T20:04:36.194Z] GHSA: GHSA-9hxf-ppjv-w6rq

[2023-08-29T20:04:36.194Z] Criticality: Medium

[2023-08-29T20:04:36.194Z] URL: https://github.com/grpc/grpc/releases/tag/v1.53.1

[2023-08-29T20:04:36.194Z] Title: gRPC connection termination issue

[2023-08-29T20:04:36.194Z] Solution: upgrade to >= 1.53.0

[2023-08-29T20:04:36.194Z] 

[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.194Z] CVE: CVE-2023-1428

[2023-08-29T20:04:36.194Z] GHSA: GHSA-6628-q6j9-w8vg

[2023-08-29T20:04:36.194Z] Criticality: High

[2023-08-29T20:04:36.194Z] URL: https://github.com/grpc/grpc/issues/33463

[2023-08-29T20:04:36.194Z] Title: gRPC Reachable Assertion issue

[2023-08-29T20:04:36.194Z] Solution: upgrade to >= 1.53.0

[2023-08-29T20:04:36.194Z] 

[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.194Z] CVE: CVE-2023-32731

[2023-08-29T20:04:36.194Z] GHSA: GHSA-cfgp-2977-2fmm

[2023-08-29T20:04:36.194Z] Criticality: High

[2023-08-29T20:04:36.194Z] URL: https://github.com/grpc/grpc/issues/33463

[2023-08-29T20:04:36.194Z] Title: Connection confusion in gRPC

[2023-08-29T20:04:36.194Z] Solution: upgrade to >= 1.53.1

[2023-08-29T20:04:36.194Z] 

[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.194Z] CVE: CVE-2023-32732

[2023-08-29T20:04:36.194Z] GHSA: GHSA-9hxf-ppjv-w6rq

[2023-08-29T20:04:36.194Z] Criticality: Medium

[2023-08-29T20:04:36.194Z] URL: https://github.com/grpc/grpc/releases/tag/v1.53.1

[2023-08-29T20:04:36.194Z] Title: gRPC connection termination issue

[2023-08-29T20:04:36.194Z] Solution: upgrade to >= 1.53.0

[2023-08-29T20:04:36.194Z] 

[2023-08-29T20:04:36.194Z] Name: grpc

[2023-08-29T20:04:36.194Z] Version: 1.50.0

[2023-08-29T20:04:36.195Z] CVE: CVE-2023-1428

[2023-08-29T20:04:36.195Z] GHSA: GHSA-6628-q6j9-w8vg

[2023-08-29T20:04:36.195Z] Criticality: High

[2023-08-29T20:04:36.195Z] URL: https://github.com/grpc/grpc/issues/33463

[2023-08-29T20:04:36.195Z] Title: gRPC Reachable Assertion issue

[2023-08-29T20:04:36.195Z] Solution: upgrade to >= 1.53.0

[2023-08-29T20:04:36.195Z] 

[2023-08-29T20:04:36.195Z] Name: grpc

[2023-08-29T20:04:36.195Z] Version: 1.50.0

[2023-08-29T20:04:36.195Z] CVE: CVE-2023-32731

[2023-08-29T20:04:36.195Z] GHSA: GHSA-cfgp-2977-2fmm

[2023-08-29T20:04:36.195Z] Criticality: High

[2023-08-29T20:04:36.195Z] URL: https://github.com/grpc/grpc/issues/33463

[2023-08-29T20:04:36.195Z] Title: Connection confusion in gRPC

[2023-08-29T20:04:36.195Z] Solution: upgrade to >= 1.53.1

[2023-08-29T20:04:36.195Z] 

[2023-08-29T20:04:36.195Z] Name: grpc

[2023-08-29T20:04:36.195Z] Version: 1.50.0

[2023-08-29T20:04:36.195Z] CVE: CVE-2023-32732

[2023-08-29T20:04:36.195Z] GHSA: GHSA-9hxf-ppjv-w6rq

[2023-08-29T20:04:36.195Z] Criticality: Medium

[2023-08-29T20:04:36.195Z] URL: https://github.com/grpc/grpc/releases/tag/v1.53.1

[2023-08-29T20:04:36.195Z] Title: gRPC connection termination issue

[2023-08-29T20:04:36.195Z] Solution: upgrade to >= 1.53.0
```