### PR TITLE
[PLAT-3986] Add PR Agent to repo

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,12 @@
+name: PR-Agent
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr_agent_job:
+    uses: apartmentlist/github-actions/.github/workflows/pr-agent.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the centralized PR-Agent GitHub Actions workflow. Once merged, PR-Agent will automatically review all new pull requests.

See https://github.com/apartmentlist/github-actions/blob/main/.github/workflows/pr-agent.yml for configuration details.