### PR TITLE
[PI-1462] - Upgrade to google-cloud-pubsub 3.x

### DIFF
--- a/.ci
+++ b/.ci
@@ -39,22 +39,8 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-  - name: ruby27
-    image: gcr.io/alist-development/ruby:2.7.5
-    imagePullPolicy: Always
-    resources:
-      requests:
-        memory: "1024Mi"
-        cpu: "1"
-      limits:
-        memory: "1024Mi"
-        cpu: "1"
-    command:
-    - "tail"
-    - "-f"
-    - "/dev/null"
-  - name: ruby30
-    image: gcr.io/alist-development/ruby:3.0.3
+  - name: ruby32
+    image: gcr.io/alist-development/ruby:3.2.5
     imagePullPolicy: Always
     resources:
       requests:
@@ -82,25 +68,12 @@ spec:
 
   stages {
     stage('Unit Tests') {
-      parallel {
-        stage('Ruby 2.7') {
-          steps {
-            container('ruby27') {
-              sh script: 'gem install bundler:2.3.12 && bundle install', label: 'install'
-              sh script: 'bundle exec rake', label: 'test'
-            } //container
-          } //steps
-        }//stage
-
-        stage('Ruby 3.0') {
-          steps {
-            container('ruby30') {
-              sh script: 'gem install bundler:2.3.12 && bundle install', label: 'install'
-              sh script: 'bundle exec rake', label: 'test'
-            } //container
-          } //steps
-        }//stage
-      } //parallel
+      steps {
+        container('ruby32') {
+          sh script: 'gem install bundler:2.3.12 && bundle install', label: 'install'
+          sh script: 'bundle exec rake', label: 'test'
+        } //container
+      } //steps
     } //stage
 
     stage("Preparation") {
@@ -127,7 +100,7 @@ spec:
       parallel {
         stage("to Github packages") {
           steps {
-            publishRubyGemToGHP("ruby30")
+            publishRubyGemToGHP("ruby32")
           }
         } // stage - to Github packages
       } // parallel

--- a/.ci
+++ b/.ci
@@ -39,8 +39,8 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-  - name: ruby32
-    image: gcr.io/alist-development/ruby:3.2.5
+  - name: ruby31
+    image: gcr.io/alist-development/ruby:3.1.4-slim
     imagePullPolicy: Always
     resources:
       requests:
@@ -69,7 +69,7 @@ spec:
   stages {
     stage('Unit Tests') {
       steps {
-        container('ruby32') {
+        container('ruby31') {
           sh script: 'gem install bundler:2.3.12 && bundle install', label: 'install'
           sh script: 'bundle exec rake', label: 'test'
         } //container
@@ -100,7 +100,7 @@ spec:
       parallel {
         stage("to Github packages") {
           steps {
-            publishRubyGemToGHP("ruby32")
+            publishRubyGemToGHP("ruby31")
           }
         } // stage - to Github packages
       } // parallel

--- a/.ci
+++ b/.ci
@@ -46,7 +46,7 @@ spec:
       requests:
         memory: "1024Mi"
         cpu: "1"
-      requests:
+      limits:
         memory: "1024Mi"
         cpu: "1"
     command:
@@ -60,7 +60,7 @@ spec:
       requests:
         memory: "1024Mi"
         cpu: "1"
-      requests:
+      limits:
         memory: "1024Mi"
         cpu: "1"
     command:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,11 @@
+Version 3.0.0 2026-06-22
+------------------------
+Upgrade to google-cloud-pubsub ~> 3.0
+- Topic/Subscription data-plane classes renamed to Publisher/Subscriber
+  (pubsub.topic -> pubsub.publisher, pubsub.subscription -> pubsub.subscriber)
+- Topic/subscription existence now verified via the admin clients
+  (topic_admin.get_topic / subscription_admin.get_subscription)
+
 Version 2.0.0 2021-03-30
 ------------------------
 172dc19 Add support for multiple clients

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,9 @@
 Version 3.0.0 2026-06-22
 ------------------------
+Require Ruby ~> 3.1
 Upgrade to google-cloud-pubsub ~> 3.0
 - Topic/Subscription data-plane classes renamed to Publisher/Subscriber
-  (pubsub.topic -> pubsub.publisher, pubsub.subscription -> pubsub.subscriber)
 - Topic/subscription existence now verified via the admin clients
-  (topic_admin.get_topic / subscription_admin.get_subscription)
 
 Version 2.0.0 2021-03-30
 ------------------------

--- a/lib/pubsub_client/publisher.rb
+++ b/lib/pubsub_client/publisher.rb
@@ -4,31 +4,31 @@ require 'google/cloud/pubsub'
 
 class PubsubClient
   class Publisher
-    # @param topic [Google::Cloud::PubSub::Topic]
-    def initialize(topic)
-      @topic = topic
+    # @param publisher [Google::Cloud::PubSub::Publisher]
+    def initialize(publisher)
+      @publisher = publisher
     end
 
     def publish(message, attributes = {}, &block)
-      topic.publish_async(message, attributes, &block)
+      publisher.publish_async(message, attributes, &block)
     end
 
-    # https://googleapis.dev/ruby/google-cloud-pubsub/latest/Google/Cloud/PubSub/Topic.html#publish-instance_method
+    # https://cloud.google.com/ruby/docs/reference/google-cloud-pubsub/latest/Google-Cloud-PubSub-Publisher#Google__Cloud__PubSub__Publisher_publish_instance_
     #
     # @return [Google::Cloud::PubSub::Message | Array<Google::Cloud::PubSub::Message>]
     #         Returns the published message when called without a block, or an array of messages
     #         when called with a block.
     def synchronous_publish(message, attributes = {}, &block)
-      topic.publish(message, attributes, &block)
+      publisher.publish(message, attributes, &block)
     end
 
     def flush
-      return unless topic.async_publisher
-      topic.async_publisher.stop.wait!
+      return unless publisher.async_publisher
+      publisher.async_publisher.stop.wait!
     end
 
     private
 
-    attr_reader :topic
+    attr_reader :publisher
   end
 end

--- a/lib/pubsub_client/publisher_factory.rb
+++ b/lib/pubsub_client/publisher_factory.rb
@@ -69,8 +69,6 @@ class PubsubClient
       Publisher.new(pubsub.publisher(topic_name))
     end
 
-    # In google-cloud-pubsub v3, `pubsub.publisher` returns a reference without
-    # performing a server lookup, so we verify existence via the admin client.
     def ensure_topic_exists!(pubsub, topic_name)
       pubsub.topic_admin.get_topic(topic: pubsub.topic_path(topic_name))
     rescue Google::Cloud::NotFoundError

--- a/lib/pubsub_client/publisher_factory.rb
+++ b/lib/pubsub_client/publisher_factory.rb
@@ -54,9 +54,8 @@ class PubsubClient
 
     def build_publisher(topic_name)
       pubsub = Google::Cloud::PubSub.new
-      topic = pubsub.topic(topic_name)
-      raise InvalidTopicError, "The topic #{topic_name} does not exist" unless topic
-      publisher = Publisher.new(topic)
+      ensure_topic_exists!(pubsub, topic_name)
+      publisher = Publisher.new(pubsub.publisher(topic_name))
 
       at_exit { publisher.flush }
 
@@ -65,10 +64,17 @@ class PubsubClient
 
     def build_synchronous(topic_name, publish_timeout)
       pubsub = Google::Cloud::PubSub.new(timeout: publish_timeout)
-      topic = pubsub.topic(topic_name)
-      raise InvalidTopicError, "The topic #{topic_name} does not exist" unless topic
+      ensure_topic_exists!(pubsub, topic_name)
 
-      Publisher.new(topic)
+      Publisher.new(pubsub.publisher(topic_name))
+    end
+
+    # In google-cloud-pubsub v3, `pubsub.publisher` returns a reference without
+    # performing a server lookup, so we verify existence via the admin client.
+    def ensure_topic_exists!(pubsub, topic_name)
+      pubsub.topic_admin.get_topic(topic: pubsub.topic_path(topic_name))
+    rescue Google::Cloud::NotFoundError
+      raise InvalidTopicError, "The topic #{topic_name} does not exist"
     end
   end
 end

--- a/lib/pubsub_client/subscriber.rb
+++ b/lib/pubsub_client/subscriber.rb
@@ -6,19 +6,19 @@ class PubsubClient
   class Subscriber
     DEFAULT_CONCURRENCY = 8
 
-    # @param subscription [Google::Cloud::PubSub::Subscription]
-    def initialize(subscription)
-      @subscription = subscription
+    # @param subscriber [Google::Cloud::PubSub::Subscriber]
+    def initialize(subscriber)
+      @subscriber = subscriber
     end
 
     # @param concurrency [Integer] - The number of threads to run the subscriber with. Default is 8.
     # @param auto_ack [Boolean] - Flag to acknowledge the Pub/Sub message. A message must be acked
     # to remove it from the topic. Default is `true`.
     #
-    # @return [Google::Cloud::PubSub::Subscriber]
+    # @return [Google::Cloud::PubSub::MessageListener]
     def listener(concurrency: DEFAULT_CONCURRENCY, auto_ack: true, &block)
       @listener ||= begin
-        @subscription.listen(threads: { callback: concurrency }) do |received_message|
+        @subscriber.listen(threads: { callback: concurrency }) do |received_message|
           yield received_message.data, received_message
           received_message.acknowledge! if auto_ack
         end

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -22,9 +22,18 @@ class PubsubClient
 
     def build_subscriber(subscription_name)
       pubsub = Google::Cloud::PubSub.new
-      subscription = pubsub.subscription(subscription_name)
-      raise InvalidSubscriptionError, "The subscription #{subscription_name} does not exist" unless subscription
-      Subscriber.new(subscription)
+      ensure_subscription_exists!(pubsub, subscription_name)
+      Subscriber.new(pubsub.subscriber(subscription_name))
+    end
+
+    # In google-cloud-pubsub v3, `pubsub.subscriber` returns a reference without
+    # performing a server lookup, so we verify existence via the admin client.
+    def ensure_subscription_exists!(pubsub, subscription_name)
+      pubsub.subscription_admin.get_subscription(
+        subscription: pubsub.subscription_path(subscription_name)
+      )
+    rescue Google::Cloud::NotFoundError
+      raise InvalidSubscriptionError, "The subscription #{subscription_name} does not exist"
     end
   end
 end

--- a/lib/pubsub_client/subscriber_factory.rb
+++ b/lib/pubsub_client/subscriber_factory.rb
@@ -26,8 +26,6 @@ class PubsubClient
       Subscriber.new(pubsub.subscriber(subscription_name))
     end
 
-    # In google-cloud-pubsub v3, `pubsub.subscriber` returns a reference without
-    # performing a server lookup, so we verify existence via the admin client.
     def ensure_subscription_exists!(pubsub, subscription_name)
       pubsub.subscription_admin.get_subscription(
         subscription: pubsub.subscription_path(subscription_name)

--- a/lib/pubsub_client/version.rb
+++ b/lib/pubsub_client/version.rb
@@ -1,3 +1,3 @@
 class PubsubClient
-  VERSION = '2.1.1'
+  VERSION = '3.0.0'
 end

--- a/pubsub_client.gemspec
+++ b/pubsub_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'google-cloud-pubsub', '~> 2.0'
+  spec.add_runtime_dependency 'google-cloud-pubsub', '~> 3.0'
   spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/pubsub_client.gemspec
+++ b/pubsub_client.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Google Pub/Sub Wrapper}
   spec.homepage      = 'https://github.com/apartmentlist/pubsub_client'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/spec/pubsub_client/publisher_factory_spec.rb
+++ b/spec/pubsub_client/publisher_factory_spec.rb
@@ -5,7 +5,8 @@ class PubsubClient
     subject(:factory) { described_class.new }
 
     let(:pubsub) { instance_double(Google::Cloud::PubSub::Project) }
-    let(:topic) { instance_double(Google::Cloud::PubSub::Topic) }
+    let(:topic_admin) { double('topic_admin') }
+    let(:gcloud_publisher) { instance_double(Google::Cloud::PubSub::Publisher) }
     let(:publisher) do
       # The factory ensures the #flush method of publisher is called on exit, so
       # we cannot use doubles. Thus, created a lightweight object that will respond
@@ -17,10 +18,13 @@ class PubsubClient
       allow(Google::Cloud::PubSub)
         .to receive(:new)
         .and_return(pubsub)
+      allow(pubsub).to receive(:topic_admin).and_return(topic_admin)
+      allow(pubsub).to receive(:topic_path) { |name| "projects/test/topics/#{name}" }
+      allow(topic_admin).to receive(:get_topic)
       allow(pubsub)
-        .to receive(:topic)
+        .to receive(:publisher)
         .with('the-topic')
-        .and_return(topic)
+        .and_return(gcloud_publisher)
       allow(Publisher)
         .to receive(:new)
         .and_return(publisher)
@@ -42,14 +46,14 @@ class PubsubClient
           factory.build('the-topic')
         end
 
-        expect(pubsub).to have_received(:topic).twice
+        expect(pubsub).to have_received(:publisher).twice
       end
     end
 
     it 'builds the publisher' do
       factory.build('the-topic')
       expect(Publisher).to have_received(:new)
-        .with(topic)
+        .with(gcloud_publisher)
     end
 
     it 'returns the publisher' do
@@ -58,10 +62,10 @@ class PubsubClient
 
     context 'when the topic does not exist' do
       before do
-        allow(pubsub)
-          .to receive(:topic)
-          .with('invalid-topic')
-          .and_return(nil)
+        allow(topic_admin)
+          .to receive(:get_topic)
+          .with(topic: 'projects/test/topics/invalid-topic')
+          .and_raise(Google::Cloud::NotFoundError.new('not found'))
       end
 
       it 'raises an error' do
@@ -72,8 +76,8 @@ class PubsubClient
     end
 
     context 'multiple topics' do
-      let(:topic1) { instance_double(Google::Cloud::PubSub::Topic, name: '/projects/project-identifier/topics/topic-1') }
-      let(:topic2) { instance_double(Google::Cloud::PubSub::Topic, name: '/projects/project-identifier/topics/topic-2') }
+      let(:gcloud_publisher1) { instance_double(Google::Cloud::PubSub::Publisher, name: '/projects/project-identifier/topics/topic-1') }
+      let(:gcloud_publisher2) { instance_double(Google::Cloud::PubSub::Publisher, name: '/projects/project-identifier/topics/topic-2') }
 
       # We need a way to distinguish between these objects and setting an `id`
       # attribute will allow us to do that.
@@ -82,20 +86,20 @@ class PubsubClient
 
       before do
         allow(pubsub)
-          .to receive(:topic)
+          .to receive(:publisher)
           .with('topic-1')
-          .and_return(topic1)
+          .and_return(gcloud_publisher1)
         allow(pubsub)
-          .to receive(:topic)
+          .to receive(:publisher)
           .with('topic-2')
-          .and_return(topic2)
+          .and_return(gcloud_publisher2)
         allow(Publisher)
           .to receive(:new)
-          .with(topic1)
+          .with(gcloud_publisher1)
           .and_return(publisher1)
         allow(Publisher)
           .to receive(:new)
-          .with(topic2)
+          .with(gcloud_publisher2)
           .and_return(publisher2)
       end
 
@@ -110,10 +114,10 @@ class PubsubClient
           factory.build('topic-2')
         end
 
-        expect(pubsub).to have_received(:topic)
+        expect(pubsub).to have_received(:publisher)
           .with('topic-1')
           .once
-        expect(pubsub).to have_received(:topic)
+        expect(pubsub).to have_received(:publisher)
           .with('topic-2')
           .once
       end
@@ -128,7 +132,7 @@ class PubsubClient
 
       it 'builds the synchronous publisher' do
         factory.build('the-topic', 5)
-        expect(Google::Cloud::Pubsub).to have_received(:new)
+        expect(Google::Cloud::PubSub).to have_received(:new)
           .with(timeout: 5)
       end
     end

--- a/spec/pubsub_client/publisher_spec.rb
+++ b/spec/pubsub_client/publisher_spec.rb
@@ -2,26 +2,26 @@
 
 class PubsubClient
   RSpec.describe Publisher do
-    subject(:publisher) { described_class.new(topic) }
+    subject(:publisher) { described_class.new(gcloud_publisher) }
 
-    let(:topic) { instance_double(Google::Cloud::PubSub::Topic) }
+    let(:gcloud_publisher) { instance_double(Google::Cloud::PubSub::Publisher) }
 
     describe 'async publishing' do
       before do
-        allow(topic)
+        allow(gcloud_publisher)
           .to receive(:publish_async)
           .and_yield('the-result')
       end
 
       it 'publishes the message' do
         subject.publish('foo') { |_| }
-        expect(topic).to have_received(:publish_async)
+        expect(gcloud_publisher).to have_received(:publish_async)
           .with('foo', {})
       end
 
       it 'supports attributes' do
         subject.publish('foo', bar: 'baz') { |_| }
-        expect(topic).to have_received(:publish_async)
+        expect(gcloud_publisher).to have_received(:publish_async)
           .with('foo', {bar: 'baz'})
       end
 
@@ -36,18 +36,18 @@ class PubsubClient
 
     describe 'synchronous publishing' do
       before do
-        allow(topic).to receive(:publish)
+        allow(gcloud_publisher).to receive(:publish)
       end
 
       it 'publishes the message' do
         subject.synchronous_publish('foo')
-        expect(topic).to have_received(:publish)
+        expect(gcloud_publisher).to have_received(:publish)
           .with('foo', {})
       end
 
       it 'supports attributes' do
         subject.synchronous_publish('foo', bar: 'baz')
-        expect(topic).to have_received(:publish)
+        expect(gcloud_publisher).to have_received(:publish)
           .with('foo', {bar: 'baz'})
       end
     end # describe

--- a/spec/pubsub_client/subscriber_factory_spec.rb
+++ b/spec/pubsub_client/subscriber_factory_spec.rb
@@ -5,17 +5,21 @@ class PubsubClient
     subject(:factory) { described_class.new }
 
     let(:pubsub) { instance_double(Google::Cloud::PubSub::Project) }
-    let(:subscription) { instance_double(Google::Cloud::PubSub::Subscription) }
+    let(:subscription_admin) { double('subscription_admin') }
+    let(:gcloud_subscriber) { instance_double(Google::Cloud::PubSub::Subscriber) }
     let(:subscriber) { instance_double(Subscriber) }
 
     before do
       allow(Google::Cloud::PubSub)
         .to receive(:new)
         .and_return(pubsub)
+      allow(pubsub).to receive(:subscription_admin).and_return(subscription_admin)
+      allow(pubsub).to receive(:subscription_path) { |name| "projects/test/subscriptions/#{name}" }
+      allow(subscription_admin).to receive(:get_subscription)
       allow(pubsub)
-        .to receive(:subscription)
+        .to receive(:subscriber)
         .with('the-subscription')
-        .and_return(subscription)
+        .and_return(gcloud_subscriber)
       allow(Subscriber)
         .to receive(:new)
         .and_return(subscriber)
@@ -24,7 +28,7 @@ class PubsubClient
     it 'builds the subscriber' do
       factory.build('the-subscription')
       expect(Subscriber).to have_received(:new)
-        .with(subscription)
+        .with(gcloud_subscriber)
     end
 
     it 'returns the subscriber' do
@@ -33,10 +37,10 @@ class PubsubClient
 
     context 'when the subscription does not exist' do
       before do
-        allow(pubsub)
-          .to receive(:subscription)
-          .with('invalid-subscription')
-          .and_return(nil)
+        allow(subscription_admin)
+          .to receive(:get_subscription)
+          .with(subscription: 'projects/test/subscriptions/invalid-subscription')
+          .and_raise(Google::Cloud::NotFoundError.new('not found'))
       end
 
       it 'raises an error' do

--- a/spec/pubsub_client/subscriber_spec.rb
+++ b/spec/pubsub_client/subscriber_spec.rb
@@ -2,10 +2,10 @@
 
 class PubsubClient
   RSpec.describe Subscriber do
-    subject(:subscriber) { described_class.new(subscription) }
+    subject(:subscriber) { described_class.new(gcloud_subscriber) }
 
-    let(:subscription) { instance_double(Google::Cloud::PubSub::Subscription) }
-    let(:listener) { instance_double(Google::Cloud::PubSub::Subscriber) }
+    let(:gcloud_subscriber) { instance_double(Google::Cloud::PubSub::Subscriber) }
+    let(:listener) { instance_double(Google::Cloud::PubSub::MessageListener) }
     let(:pubsub_message) {
       instance_double(Google::Cloud::PubSub::ReceivedMessage, data: 'the-message', acknowledge!: nil)
     }
@@ -14,7 +14,7 @@ class PubsubClient
       # This must be stubbed out so that the process that runs the specs doesn't
       # actually sleep.
       allow(subscriber).to receive(:sleep)
-      allow(subscription).to receive(:listen)
+      allow(gcloud_subscriber).to receive(:listen)
         .with({ threads: { callback: 8 } })
         .and_yield(pubsub_message)
         .and_return(listener)


### PR DESCRIPTION
[PI-1462](https://apartmentlist.atlassian.net/browse/PI-1462)

We need to update the Faraday gem in billing to address multiple CVEs, but in order to do that, we need to adjust our internal gems as well. The current version of `google-cloud-pubsub` requires an older version of `googleauth`, which requires an older version of `faraday`.

Upgrading to `google-cloud-pubsub` 3.0 is not without its big changes:
* `Topic` has been renamed to `Publisher`, which accounts for the majority of the changes here
* The API has changed for `topic.async_publisher`
* `pubsub.subscription` has been renamed to `pubsub.subscriber`, and we now `.listen` against `subscriber`, not `subscription`

🪲 🐶 

[PI-1462]: https://apartmentlist.atlassian.net/browse/PI-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ